### PR TITLE
lxc-slopster: add pcbparts mcp

### DIFF
--- a/hosts/lxc-slopster/configuration.nix
+++ b/hosts/lxc-slopster/configuration.nix
@@ -44,6 +44,11 @@
         provider = "openai-codex";
         base_url = "https://chatgpt.com/backend-api/codex";
       };
+      mcp_servers = {
+        pcbparts = {
+          url = "https://pcbparts.dev/mcp";
+        };
+      };
       toolsets = [
         "all"
       ];


### PR DESCRIPTION
## summary
- add the pcbparts MCP server to the lxc-slopster Hermes config

## testing
- nix build .#nixosConfigurations.lxc-slopster.config.system.build.toplevel --no-link